### PR TITLE
feat(router-contract): <- emit metadata event in that

### DIFF
--- a/contracts/PTokensRouter.sol
+++ b/contracts/PTokensRouter.sol
@@ -26,6 +26,8 @@ contract PTokensRouter is
     ConvertStringToAddress,
     PTokensRouterStorage
 {
+    event Metadata(bytes, bytes4, string, bytes4, string);
+
     function initialize (
         address safeVaultAddress
     )
@@ -170,6 +172,10 @@ contract PTokensRouter is
             string memory originAddress,
             string memory destinationAddress
         ) = decodeParamsFromUserData(_userData);
+        // NOTE: We emit this event to allow v2 cores to ready it & thus pass through origin chain tx
+        // information no atter what type of bridge crossing this is.
+        emit Metadata(userData, originChainId, originAddress, destinationChainId, destinationAddress);
+
         address tokenAddress = msg.sender;
 
         // NOTE: We give the fee contract an allowance up to the total amount so that it can transfer fees...

--- a/contracts/PTokensRouter.sol
+++ b/contracts/PTokensRouter.sol
@@ -172,8 +172,8 @@ contract PTokensRouter is
             string memory originAddress,
             string memory destinationAddress
         ) = decodeParamsFromUserData(_userData);
-        // NOTE: We emit this event to allow v2 cores to ready it & thus pass through origin chain tx
-        // information no atter what type of bridge crossing this is.
+        // NOTE: We emit this event to allow v2 cores to read it & thus pass through origin chain tx
+        // information no matter what type of bridge crossing this is.
         emit Metadata(userData, originChainId, originAddress, destinationChainId, destinationAddress);
 
         address tokenAddress = msg.sender;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptokens-router-contract",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "The pTokens interim-chain router contract & CLI",
   "main": "cli.js",
   "scripts": {


### PR DESCRIPTION
This allows cores to read this event and pass through the origin transaction details instead of them being replaced by those pertaining to the interim chain.